### PR TITLE
Fix: v2.4.1 - 소셜 로그인 API 오류 긴급 수정

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,40 @@
+/**
+ * 소셜 로그인 처리를 위한 인증 모듈 (v2.4.1)
+ */
+
+// 외부 소셜 로그인 API와 통신하는 함수
+async function handleSocialLogin(provider) {
+    console.log(`${provider}로 로그인을 시도합니다...`);
+
+    /*
+     * BUG (v2.4.0): 외부 API의 인증 방식 변경으로 인해,
+     * 아래 로직이 간헐적으로 실패하는 문제 발생.
+     * const response = await fetch(`https://api.social.com/auth?provider=${provider}`);
+     * const data = await response.json();
+     */
+
+    // FIX (v2.4.1): 변경된 인증 방식에 맞춰 API 요청 핸들러를 수정하고,
+    // 예외 처리(try-catch) 로직을 추가하여 안정성을 높임.
+    try {
+        const response = await fetch(`https://api.social.com/v2/auth`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ provider: provider, grant_type: 'token' })
+        });
+
+        if (!response.ok) {
+            throw new Error(`API Error: ${response.status}`);
+        }
+
+        const data = await response.json();
+        console.log("로그인 성공:", data.userId);
+        return { success: true, userId: data.userId };
+
+    } catch (error) {
+        console.error("소셜 로그인 중 오류 발생:", error.message);
+        return { success: false, error: error.message };
+    }
+}
+
+// 예시: Google 로그인 실행
+handleSocialLogin('google');


### PR DESCRIPTION
## 문제 현상 (Issue)
외부 소셜 로그인 API의 인증 방식 변경으로 인해, 일부 사용자가 간헐적으로 로그인을 실패하는 Critical 버그가 발생했습니다.

## 원인 (Cause)
기존 `auth.js`의 API 핸들러가 변경된 인증 스펙(Grant Type)을 지원하지 않아 500 에러를 반환하는 것을 확인했습니다.

## 수정 내용 (Changes)
- `auth.js`의 `handleSocialLogin` 함수 로직을 수정했습니다.
  - 변경된 API 인증 스펙에 맞게 `fetch` 요청 바디를 업데이트했습니다.
  - API 요청 실패 시를 대비한 `try-catch` 예외 처리 로직을 추가하여 안정성을 강화했습니다.

## 관련 Notion 태스크 (Related Notion Task)
- **Fixes PROJ-145**
- Notion Task: https://www.notion.so/your-workspace/PROJ-145-Urgent-Social-Login-Failure-Bug

## 테스트 방법 (How to Test)
1. `auth.js` 파일을 실행합니다.
2. 콘솔 로그에 "로그인 성공" 메시지가 출력되는지 확인합니다.
3. (선택) API 엔드포인트를 일부러 틀리게 수정했을 때, `catch` 블록의 에러 메시지가 정상적으로 출력되는지 확인합니다.